### PR TITLE
[FIX] unused vars in Typescript types

### DIFF
--- a/template/.eslintrc
+++ b/template/.eslintrc
@@ -80,7 +80,7 @@
     "react/jsx-uses-react": ["error"],
     "react/jsx-uses-vars": ["error"],
     "react/react-in-jsx-scope": ["error"],
-    "no-unused-vars": [
+    "@typescript-eslint/no-unused-vars": [
       "error",
       { "vars": "local", "args": "after-used", "ignoreRestSiblings": false }
     ],


### PR DESCRIPTION
I had this error while starting the project with TS
![Screenshot-20201212232512-684x245](https://user-images.githubusercontent.com/18385321/102003239-937a5a00-3cd2-11eb-8c9d-f7ad40ee1ac5.png)

I found this rule https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md that fixed the error, 